### PR TITLE
Add support for gap8

### DIFF
--- a/src/toolbelt/config.json
+++ b/src/toolbelt/config.json
@@ -18,6 +18,9 @@
     ],
     "bitcraze/fpga-builder": [
       "ice40"
+    ],
+    "bitcraze/aideck": [
+      "gap8"
     ]
   }
 }


### PR DESCRIPTION
Add support for building GAP8 code.
This is perhaps semi-temporary as the builder image probably should be renamed to something like gap8-builder